### PR TITLE
Repetition elimination

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="Encoding">
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/src/main/java/pl/put/poznan/transformer/logic/RepetitionEliminationTransformer.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/RepetitionEliminationTransformer.java
@@ -1,0 +1,28 @@
+package pl.put.poznan.transformer.logic;
+
+import pl.put.poznan.transformer.logic.base.TextDecorator;
+import pl.put.poznan.transformer.logic.base.TextTransformerInterface;
+
+public class RepetitionEliminationTransformer extends TextDecorator {
+
+    public RepetitionEliminationTransformer(TextTransformerInterface text) {
+        super(text);
+    }
+
+    @Override
+    public String getText() {
+        return transformText(super.getText());
+    }
+
+    private String transformText(String text) {
+        try {
+            return translate(text);
+        } catch (NumberFormatException nfe) {
+            return text;
+        }
+    }
+
+    private String translate(String text) {
+        return text;
+    }
+}

--- a/src/main/java/pl/put/poznan/transformer/logic/RepetitionEliminationTransformer.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/RepetitionEliminationTransformer.java
@@ -3,6 +3,10 @@ package pl.put.poznan.transformer.logic;
 import pl.put.poznan.transformer.logic.base.TextDecorator;
 import pl.put.poznan.transformer.logic.base.TextTransformerInterface;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class RepetitionEliminationTransformer extends TextDecorator {
 
     public RepetitionEliminationTransformer(TextTransformerInterface text) {
@@ -23,6 +27,25 @@ public class RepetitionEliminationTransformer extends TextDecorator {
     }
 
     private String translate(String text) {
-        return text;
+        String textSplit[] = text.split("\\s+");
+        List<String> words = new ArrayList<String>(Arrays.asList(textSplit));
+        Boolean no_repetition = false;
+        String result = "";
+
+        while (no_repetition == false){
+            result = words.get(0);
+            no_repetition = true;
+            for (int i = 1; i < words.size(); i++) {
+                if (!words.get(i).equals(words.get(i-1))) {
+                    result += " " + words.get(i);
+                }
+                else{
+                    words.remove(i);
+                    i++;
+                    no_repetition = false;
+                }
+            }
+        }
+        return result;
     }
 }

--- a/src/test/java/unit/RepetitionEliminationTransformerTest.java
+++ b/src/test/java/unit/RepetitionEliminationTransformerTest.java
@@ -1,0 +1,38 @@
+package unit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import pl.put.poznan.transformer.logic.CapitalizedInversionTransformer;
+import pl.put.poznan.transformer.logic.RepetitionEliminationTransformer;
+import pl.put.poznan.transformer.logic.base.Text;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class RepetitionEliminationTransformerTest {
+
+    static Stream<Arguments> transformsArgumentsProvider() {
+        return Stream.of(
+                arguments("Wyślij do do mnie wiadomość", "Wyślij do mnie wiadomość"),
+                arguments("do do do", "do"),
+                arguments("do do", "do"),
+                arguments("do do po po", "do po"),
+                arguments("Du du du duuum!", "Du du duuum!"),
+                arguments("Cyberpunk Cyberpunk Cyberpunk Cyberpunk 2077", "Cyberpunk 2077"),
+                arguments("❄︎⍓︎◻︎♏︎ ⍓︎□︎◆︎❒︎ ⧫︎♏︎⌧︎⧫︎ ⧫︎♏︎⌧︎⧫︎ ⧫︎♏︎⌧︎⧫︎ ⧫︎♏︎⌧︎⧫︎ ♒︎♏︎❒︎♏︎", "❄︎⍓︎◻︎♏︎ ⍓︎□︎◆︎❒︎ ⧫︎♏︎⌧︎⧫︎ ♒︎♏︎❒︎♏︎"),
+                arguments("≻≼≽≾ ≻≼≽≾ ≻≼≽≾ ≻≼≽≾ ≿⊁ ≿⊁ ⊂⊃ ⊄⊅ ⊄⊅", "≻≼≽≾ ≿⊁ ⊂⊃ ⊄⊅")
+        );
+    }
+
+    @ParameterizedTest(name = "should transform {0} into {1}")
+    @MethodSource("transformsArgumentsProvider")
+    void shouldTransform(String in, String out) {
+        String transformed_text = new RepetitionEliminationTransformer(new Text(in)).getText();
+
+        Assertions.assertEquals(transformed_text, out);
+    }
+}


### PR DESCRIPTION
- Wprowadzenie eliminacji powtórzeń sąsiednich wyrazów.
- Dodanie kompletu 8 testów, wszystkie przechodzą.
- Ponadto zmieniono kodowanie projektu do UTF-8, ponieważ ten task zakłada działanie dla wszystkich znaków UTF-8.
- Możliwe działanie niepożądane - wynik zawsze zwraca wyrazy przedzielone pojedynczymi spacjami. Tak samo jest w TextToAcronymTransformer, więc uznałem, że można na to przymknąć oko.